### PR TITLE
Show private collections only when logged in and owner on SpecialCollections and SpecialCollections/User

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3,6 +3,7 @@
 		"authors": []
 	},
 	"ext-gather-desc": "Getting stuff done.",
+	"mobile-frontend-collection-anon-view-lists": "You need to be logged in to see your Collections",
 	"mobile-frontend-collection-watchlist-title": "My Watchlist",
 	"mobile-frontend-collection-watchlist-description": "Pages I watch changes on.",
 	"mobile-frontend-collection-read-more": "Read more",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -3,6 +3,7 @@
 		"authors": []
 	},
 	"ext-gather-desc": "Extension description.",
+	"mobile-frontend-collection-anon-view-lists": "Text shown when trying to see your own collections on [[Special:Collections]] but the user is not logged in.",
 	"mobile-frontend-collection-watchlist-title": "Title used for special casing the Watchlist collection on the [[Special:Collections]] page. ",
 	"mobile-frontend-collection-watchlist-description": "Default description for special casing the Watchlist collection on the [[Special:Collections]] page.",
 	"mobile-frontend-collection-read-more": "Label for the read more link used on [[Special:Collections]].",

--- a/includes/models/Collection.php
+++ b/includes/models/Collection.php
@@ -8,17 +8,18 @@
  * A collection of pages, which are represented by the MobilePage class.
  */
 class Collection implements IteratorAggregate {
-	protected $user, $title, $description;
+	protected $user, $title, $description, $public;
 
 	/**
 	 * @param User $user that owns the collection
 	 * @param string $title
 	 * @param string $description
 	 */
-	public function __construct( User $user, $title = '', $description = '' ) {
+	public function __construct( User $user, $title = '', $description = '', $public = true ) {
 		$this->user = $user;
 		$this->title = $title;
 		$this->description = $description;
+		$this->public = $public;
 	}
 
 	/**
@@ -72,6 +73,24 @@ class Collection implements IteratorAggregate {
 	 */
 	public function getDescription() {
 		return $this->description;
+	}
+
+	/**
+	 * Returns if the list is public
+	 *
+	 * @return boolean
+	 */
+	public function isPublic() {
+		return $this->public;
+	}
+
+	/**
+	 * Set if the list is public
+	 *
+	 * @param boolean $public
+	 */
+	public function setPublic( $public ) {
+		$this->public = $public;
 	}
 
 	/**

--- a/includes/models/CollectionsList.php
+++ b/includes/models/CollectionsList.php
@@ -8,21 +8,29 @@
  * A list of collections, which are represented by the Collection class.
  */
 class CollectionsList implements IteratorAggregate {
+	protected $includePrivate;
 
 	/**
 	 * Creates a list of collection cards
 	 * @param User $user collection list owner
+	 * @param boolean $includePrivate if the list can show private collections or not
 	 */
-	public function __construct( $user ) {
-		// Get watchlist collection
-		$watchlist = new Collection(
-			$user,
-			wfMessage( 'mobile-frontend-collection-watchlist-title' ),
-			wfMessage( 'mobile-frontend-collection-watchlist-description' )
-		);
-		$watchlist->load( new WatchlistCollectionStore( $user ) );
+	public function __construct( $user, $includePrivate = false ) {
+		$this->includePrivate = $includePrivate;
 
-		$this->add( $watchlist );
+		// Get watchlist collection (private)
+		// Directly avoid adding if not owner
+		if ( $includePrivate ) {
+			$watchlist = new Collection(
+				$user,
+				wfMessage( 'mobile-frontend-collection-watchlist-title' ),
+				wfMessage( 'mobile-frontend-collection-watchlist-description' ),
+				false
+			);
+			$watchlist->load( new WatchlistCollectionStore( $user ) );
+
+			$this->add( $watchlist );
+		}
 
 		// FIXME: Add from UserCollectionStore
 	}
@@ -34,11 +42,16 @@ class CollectionsList implements IteratorAggregate {
 
 	/**
 	 * Adds a page to the collection.
+	 * If the collection to add is private, and this collection list does not include
+	 * private items, the collection won't be added
 	 *
 	 * @param Collection $collection
 	 */
 	public function add( Collection $collection ) {
-		$this->lists[] = $collection;
+		if ( $this->includePrivate ||
+			( !$this->includePrivate && $collection->isPublic() ) ) {
+			$this->lists[] = $collection;
+		}
 	}
 
 	/**

--- a/includes/specials/SpecialCollections.php
+++ b/includes/specials/SpecialCollections.php
@@ -64,6 +64,8 @@ class SpecialCollections extends SpecialPage {
 				$collection->load( new WatchlistCollectionStore( $user ) );
 			}
 		}
+		// FIXME: For empty-collection and not-allowed-to-see-this we are doing the
+		// same thing right now.
 		$this->render( new CollectionView( $collection ) );
 	}
 

--- a/includes/specials/SpecialCollections.php
+++ b/includes/specials/SpecialCollections.php
@@ -59,8 +59,9 @@ class SpecialCollections extends SpecialPage {
 		);
 		// Watchlist lives at id 0
 		if ( (int)$id === 0 ) {
-			// Load from watchlist if the $user is valid
-			if ( $this->getUser()->getName() == $user->getName() ) {
+			// Watchlist is private
+			$collection->setPublic( false );
+			if ( $this->isOwner( $user ) ) {
 				$collection->load( new WatchlistCollectionStore( $user ) );
 			}
 		}
@@ -74,7 +75,7 @@ class SpecialCollections extends SpecialPage {
 	 * @param User $user owner of collections
 	 */
 	public function renderUserCollectionsList( $user ) {
-		$collectionsList = new CollectionsList( $user );
+		$collectionsList = new CollectionsList( $user, $this->isOwner( $user ) );
 		$this->render( new CollectionsListView( $collectionsList ) );
 	}
 
@@ -89,5 +90,16 @@ class SpecialCollections extends SpecialPage {
 		$out->addModules( array( 'ext.collections.styles' ) );
 		$out->setPageTitle( $view->getTitle() );
 		$view->render( $out );
+	}
+
+	/**
+	 * Returns if the user viewing the page is the owner of the collection/list
+	 * we are viewing
+	 * @param User $user user owner of the current page
+	 *
+	 * @return boolean
+	 */
+	private function isOwner( $user ) {
+		return $this->getUser()->getName() == $user->getName();
 	}
 }

--- a/includes/specials/SpecialCollections.php
+++ b/includes/specials/SpecialCollections.php
@@ -19,6 +19,7 @@ class SpecialCollections extends SpecialPage {
 	 * @param string $subpage The name of the page to edit
 	 */
 	public function execute( $subpage ) {
+
 		if ( $subpage ) {
 			$args = explode( '/', $subpage );
 			// If there is a user argument, that's what we want to use
@@ -31,6 +32,8 @@ class SpecialCollections extends SpecialPage {
 				$user = $this->getUser();
 			}
 		} else {
+			// For listing own lists, you need to be logged in
+			$this->requireLogin( 'mobile-frontend-collection-anon-view-lists' );
 			$user = $this->getUser();
 		}
 


### PR DESCRIPTION
- Require login for SpecialCollections
- SpecialCollections and SpecialCollections/User show private collections if logged in and owner of that collections list
- Implement the concept of proper private collections in the CollectionsList and
  Collection.
- When creating a collection, it has a $public attribute that defaults to true.
- When creating a collections list, it can be with private items, or false.
  - Take into account that watchlist is private by default.
- In special collections, checking if the user logged in is the owner of the
  current thing we are going to show, pass privacy options to the CollectionsList
  model.

This also fixes going not logged in to SpecialCollections/User and seeing the
watchlist information (number of articles).
